### PR TITLE
fixed calling InvalidateSurface() in UI thread (fixes #3)

### DIFF
--- a/src/Svg.Skia.Forms/SvgImage.cs
+++ b/src/Svg.Skia.Forms/SvgImage.cs
@@ -68,7 +68,7 @@ namespace Svg.Skia.Forms
                 try
                 {
                     image.svgImage = await SvgDataResolver.LoadSvgImage(image.Source);
-                    image.InvalidateSurface();
+                    Device.BeginInvokeOnMainThread(image.InvalidateSurface);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Description of Change

Fixes crash when setting an image source in non-UI thread on iOS. No sample needed.

### Bugs Fixed ###

- Fixes issue #3

### PR Checklist ###

- [ ] Has sample (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard (`.editorconfig` and `StyleCop.Analyzer`)
- [ ] Updated documentation, if necessary ([Documentation.md](https://github.com/vividos/Svg.Skia.Forms/blob/main/Documentation.md))
