### PR TITLE
Nullable Reference type support

### DIFF
--- a/src/Svg.Skia.Forms/Svg.Skia.Forms.csproj
+++ b/src/Svg.Skia.Forms/Svg.Skia.Forms.csproj
@@ -5,6 +5,8 @@
     <LangVersion>9.0</LangVersion>
     <Deterministic>true</Deterministic>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <!-- NuGet package config -->

--- a/src/Svg.Skia.Forms/SvgDataResolver.cs
+++ b/src/Svg.Skia.Forms/SvgDataResolver.cs
@@ -17,7 +17,7 @@ namespace Svg.Skia.Forms
         /// <param name="source">image source to use for loading</param>
         /// <returns>loaded SVG image object</returns>
         /// <exception cref="Exception">thrown when loading has failed</exception>
-        public static async Task<SKSvg> LoadSvgImage(ImageSource source)
+        public static async Task<SKSvg?> LoadSvgImage(ImageSource source)
         {
             switch (source)
             {
@@ -76,7 +76,7 @@ namespace Svg.Skia.Forms
         {
             string text = uri.OriginalString;
 
-            string svgText = null;
+            string? svgText = null;
             if (text.StartsWith(SvgConstants.DataUriPlainPrefix, StringComparison.InvariantCultureIgnoreCase))
             {
                 svgText = text.Substring(SvgConstants.DataUriPlainPrefix.Length);

--- a/src/Svg.Skia.Forms/SvgImage.cs
+++ b/src/Svg.Skia.Forms/SvgImage.cs
@@ -15,7 +15,7 @@ namespace Svg.Skia.Forms
         /// <summary>
         /// Lazy-initialized SVG image instance
         /// </summary>
-        private SKSvg svgImage;
+        private SKSvg? svgImage;
 
         /// <summary>
         /// Creates a new SVG image control
@@ -139,7 +139,8 @@ namespace Svg.Skia.Forms
             SKCanvas canvas = args.Surface.Canvas;
             canvas.Clear();
 
-            if (this.svgImage == null)
+            if (this.svgImage == null ||
+                this.svgImage.Picture == null)
             {
                 return;
             }

--- a/src/Svg.Skia.Forms/SvgImageSourceTypeConverter.cs
+++ b/src/Svg.Skia.Forms/SvgImageSourceTypeConverter.cs
@@ -31,7 +31,7 @@ namespace Svg.Skia.Forms
         /// </summary>
         /// <param name="value">string value to convert</param>
         /// <returns>converted ImageSource object</returns>
-        public override object ConvertFromInvariantString(string value)
+        public override object? ConvertFromInvariantString(string value)
         {
             if (string.IsNullOrWhiteSpace(value))
             {
@@ -68,7 +68,7 @@ namespace Svg.Skia.Forms
         {
             resourceUri = resourceUri.Substring(SvgConstants.ResourceUriPrefix.Length);
 
-            Assembly sourceAssembly = null;
+            Assembly? sourceAssembly = null;
 
             int pos = resourceUri.IndexOf(SvgConstants.ResourceUriAssemblyQuery);
             if (pos != -1)


### PR DESCRIPTION
## Description of Change

Adds Nullable Reference type support for Svg.Skia.Forms project. No samples or documentation needed.

### Bugs Fixed ###

- Fixes #15

### PR Checklist ###

- [ ] Has sample (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to coding standard (`.editorconfig` and `StyleCop.Analyzer`)
- [ ] Updated documentation, if necessary ([Documentation.md](https://github.com/vividos/Svg.Skia.Forms/blob/main/Documentation.md))
